### PR TITLE
Upgrade to nom 1.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 authors = ["Txus <me@txus.io>"]
 
 [dependencies]
-nom = "*"
+nom = "~1.0.0"
 clippy = "*"
 hamt = "*"
 cons-list = "*"

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -71,14 +71,14 @@ pub fn parse(str: String) -> Result<AST, String> {
             Needed::Size(size) => Err(format!("incomplete parsing -- needed {} more chars", size)),
         },
         Error(e) => match e {
-            Err::Code(code) => Err(format!("parse error -- code {}", code)),
-            Err::Node(code, _) => Err(format!("parse error -- code {}, with more errors", code)),
+            Err::Code(code) => Err(format!("parse error -- code {:?}", code)),
+            Err::Node(code, _) => Err(format!("parse error -- code {:?}, with more errors", code)),
             Err::Position(code, related_input) =>
-                Err(format!("parse error -- code {}, around {:?}",
+                Err(format!("parse error -- code {:?}, around {:?}",
                             code,
                             str::from_utf8(related_input).unwrap())),
             Err::NodePosition(code, related_input, _) =>
-                Err(format!("parse error -- code {}, around {:?}",
+                Err(format!("parse error -- code {:?}, around {:?}",
                             code,
                             str::from_utf8(related_input).unwrap())),
         },
@@ -109,15 +109,15 @@ mod tests {
                     },
                     Error(e) => match e {
                         Err::Code(code) =>
-                            panic!("parse error -- code {}", code),
+                            panic!("parse error -- code {:?}", code),
                         Err::Node(code, _) =>
-                            panic!("parse error -- code {}, with more errors", code),
+                            panic!("parse error -- code {:?}, with more errors", code),
                         Err::Position(code, related_input) =>
-                            panic!("parse error -- code {}, around {:?}",
+                            panic!("parse error -- code {:?}, around {:?}",
                                    code,
                                    str::from_utf8(related_input).unwrap()),
                         Err::NodePosition(code, related_input, _) =>
-                            panic!("parse error -- code {}, around {:?}",
+                            panic!("parse error -- code {:?}, around {:?}",
                                    code,
                                    str::from_utf8(related_input).unwrap())
                     }


### PR DESCRIPTION
Hi!

nom 1.0 is here, and comes with a few breaking changes. To help the transition, and to test the beta version before release, I took the liberty to test and upgrade (if needed) your code to the 1.0 version. It should work right away, but if there are still issues, or if the code needs to be updated to your latest master, please let me know!

If you want an explanation of the changes, please take a look at the [upgrading documentation](https://github.com/Geal/nom/wiki/Upgrading-to-nom-1.0).

By the way, could you go to one (or all) of those links and write a few kind words about your experience writing parsers in Rust? It would really help me!
- [nom 1.0 release blogpost](https://www.clever-cloud.com/blog/engineering/2015/11/16/nom-1-0/)
- [Reddit post](https://www.reddit.com/r/rust/comments/3t10f3/nom_just_reached_10_cleaner_parsers_more_generic/)
- [Hacker News post](https://news.ycombinator.com/item?id=10574828)

Thank you for using nom!
